### PR TITLE
Fix Ultralytics YOLO naming conventions and example paths

### DIFF
--- a/examples/aicam/yolo-pose.py
+++ b/examples/aicam/yolo-pose.py
@@ -20,7 +20,7 @@ from modlib.models import COLOR_FORMAT, MODEL_TYPE, Model
 from modlib.models.post_processors import pp_yolo_pose_ultralytics
 
 
-class YoloPose(Model):
+class YOLOPose(Model):
     def __init__(self):
                 
         # NOTE: This Sample Code is meant to be used with AI models such as Ultralytics YOLO. Please note that
@@ -41,8 +41,8 @@ class YoloPose(Model):
         return pp_yolo_pose_ultralytics(output_tensors)
 
 
-device = AiCamera(frame_rate=17)  # Optimal frame rate for maximum DPS of the Yolo-pose model running on the AI Camera
-model = YoloPose()
+device = AiCamera(frame_rate=17)  # Optimal frame rate for maximum DPS of the YOLO-pose model running on the AI Camera
+model = YOLOPose()
 device.deploy(model)
 
 annotator = Annotator()

--- a/examples/aicam/yolo.py
+++ b/examples/aicam/yolo.py
@@ -23,7 +23,7 @@ from modlib.models import COLOR_FORMAT, MODEL_TYPE, Model
 from modlib.models.post_processors import pp_od_yolo_ultralytics
 
 
-class Yolo(Model):
+class YOLO(Model):
     def __init__(self):
         
         # NOTE: This Sample Code is meant to be used with AI models such as Ultralytics YOLO. Please note that
@@ -40,8 +40,7 @@ class Yolo(Model):
             preserve_aspect_ratio=True,
         )
 
-        self.labels = np.genfromtxt(
-            str(importlib.resources.files("modlib.models.zoo") / "assets" / "coco_labels_80.txt"),
+        self.labels = np.genfromtxt("/path/to/yolo11n_imx_model/labels.txt",
             dtype=str,
             delimiter="\n",
         )
@@ -50,8 +49,8 @@ class Yolo(Model):
         return pp_od_yolo_ultralytics(output_tensors)
 
 
-device = AiCamera(frame_rate=16)  # Optimal frame rate for maximum DPS of the Yolo model running on the AI Camera
-model = Yolo()
+device = AiCamera(frame_rate=16)  # Optimal frame rate for maximum DPS of the YOLO model running on the AI Camera
+model = YOLO()
 device.deploy(model)
 
 annotator = Annotator()

--- a/modlib/models/post_processors/post_processors.py
+++ b/modlib/models/post_processors/post_processors.py
@@ -111,7 +111,7 @@ def pp_od_bscn(output_tensors: List[np.ndarray]) -> Detections:
 def pp_od_yolo_ultralytics(output_tensors: List[np.ndarray], input_tensor_sz: int = 640) -> Detections:
     """
     Performs post-processing on an Object Detection result tensor.
-    In this case the model comes from Ultralytics Yolov8n/Yolo11n model exported
+    In this case the model comes from Ultralytics YOLOv8n/YOLO11n model exported
     for imx using ultralytics tools (onnx model).
     Compared with `pp_od_bscn`:
     - bbox xy order is different
@@ -549,7 +549,7 @@ def pp_higherhrnet(output_tensors: List[np.ndarray]) -> Poses:
 
 def pp_yolov8n_pose(output_tensors: List[np.ndarray]) -> Poses:
     """
-    Performs post-processing on a raw YoloV8n-pose result tensor.
+    Performs post-processing on a raw YOLOV8n-pose result tensor.
 
     Args:
         output_tensors: Resulting output tensors to be processed.
@@ -581,8 +581,8 @@ def pp_yolov8n_pose(output_tensors: List[np.ndarray]) -> Poses:
 
 def pp_yolo_pose_ultralytics(output_tensors: List[np.ndarray], input_tensor_sz: int = 640, num_keypoints: int = 17) -> Poses:
     """
-    Performs post-processing on a Yolo-pose result tensor.
-    In this case the model comes from the Ultralytics Yolov8n-pose/Yolo11n-pose model exported
+    Performs post-processing on a YOLO-pose result tensor.
+    In this case the model comes from the Ultralytics YOLOv8n-pose/YOLO11n-pose model exported
     for imx using ultralytics tools (onnx model).
 
     Args:
@@ -625,7 +625,7 @@ def pp_segment(output_tensors: List[np.ndarray]) -> Segments:
 
 def pp_yolov8n_segment(output_tensors: List[np.ndarray]) -> Segments:
     """
-    Performs post-processing on a raw YoloV8n-segment result tensor.
+    Performs post-processing on a raw YOLOV8n-segment result tensor.
     NOTE: The individual heatmaps for each detected segment are post processed to a single
     mask that contains the class id of the mostly likely object in that pixel.
 


### PR DESCRIPTION
This PR addresses two key issues:

1. Corrected Ultralytics YOLO naming: Changed "yolo" to "YOLO" throughout the codebase since it's an acronym (You Only Look Once) and should follow standard acronym capitalization.
2. Fixed example paths: Updated the` labels.txt` file path in examples to match the actual location in exported model folders. This ensures users can properly access their trained models without path errors.

These changes improve consistency and prevent user confusion when working with custom models.